### PR TITLE
Removed test for MakeNoise because it will be removed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,6 @@ test:
     - astconvolve --help
     - astcrop --help
     - astmatch --help
-    - astmknoise --help
     - astnoisechisel --help
     - asttable --help
 


### PR DESCRIPTION
Until now, we would check 'astmknoise' in combination with several other of Gnuastro's executables to test the build. However, MakeNoise has been removed in Gnuastro 0.21 (to be released shortly), and given all the other simple '--help' tests, it was redundant.

With this commit, to simplify future builds of Gnuastro on Conda, the 'astmknoise --help' test has been removed.